### PR TITLE
Update camel versions to latest snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo-parent</artifactId>
-    <version>4.5.1</version>
+    <version>4.6.0</version>
   </parent>
 
   <groupId>org.fcrepo.camel</groupId>
@@ -39,7 +39,7 @@
     <!-- dependencies -->
     <fcrepo.version>4.5.1</fcrepo.version>
     <fcrepo-camel.version>4.4.4-SNAPSHOT</fcrepo-camel.version>
-    <fcrepo-camel-toolbox.version>4.5.3-SNAPSHOT</fcrepo-camel-toolbox.version>
+    <fcrepo-camel-toolbox.version>4.7.0-SNAPSHOT</fcrepo-camel-toolbox.version>
 
     <activemq.version>5.13.2</activemq.version>
     <camel.version>2.17.0</camel.version>

--- a/src/test/java/org/fcrepo/camel/tests/AbstractOSGiIT.java
+++ b/src/test/java/org/fcrepo/camel/tests/AbstractOSGiIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2015 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/org/fcrepo/camel/tests/FcrepoCamelIT.java
+++ b/src/test/java/org/fcrepo/camel/tests/FcrepoCamelIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2015 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/org/fcrepo/camel/tests/FcrepoCamelToolboxIT.java
+++ b/src/test/java/org/fcrepo/camel/tests/FcrepoCamelToolboxIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2015 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/org/fcrepo/camel/tests/FcrepoIndexingTriplestoreIT.java
+++ b/src/test/java/org/fcrepo/camel/tests/FcrepoIndexingTriplestoreIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2015 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/org/fcrepo/camel/tests/FcrepoLdpathIT.java
+++ b/src/test/java/org/fcrepo/camel/tests/FcrepoLdpathIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2015 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/org/fcrepo/camel/tests/FcrepoReindexingIT.java
+++ b/src/test/java/org/fcrepo/camel/tests/FcrepoReindexingIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2015 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/org/fcrepo/camel/tests/FcrepoSerializationIT.java
+++ b/src/test/java/org/fcrepo/camel/tests/FcrepoSerializationIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2015 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *


### PR DESCRIPTION
This also updates `fcrepo-parent` version to latest release (4.6.0) and includes a corresponding update to the license headers.
